### PR TITLE
Fix Typo in the introduction page

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -1,7 +1,7 @@
 title: Dynamic Linear Economies
 author: Thomas J. Sargent and John Stachurski
 logo: _static/qe-logo-large.png
-description: This website presents a set of lectures on dynamic linear economies and tools needed for this this class of economic models.
+description: This website presents a set of lectures on dynamic linear economies and tools needed for this class of economic models.
 
 parse:
   myst_enable_extensions:
@@ -81,7 +81,7 @@ sphinx:
       twitter: quantecon
       twitter_logo_url: https://assets.quantecon.org/img/qe-twitter-logo.png
       og_logo_url: https://assets.quantecon.org/img/qe-og-logo.png
-      description: This website presents a set of lectures on dynamic linear economies and tools needed for this this class of economic models.
+      description: This website presents a set of lectures on dynamic linear economies and tools needed for this class of economic models.
       keywords: Python, QuantEcon, Quantitative Economics, Economics, Sloan, Alfred P. Sloan Foundation, Tom J. Sargent, John Stachurski
       analytics:
         google_analytics_id: G-D5TQMHKC2V

--- a/lectures/intro.md
+++ b/lectures/intro.md
@@ -11,7 +11,7 @@ kernelspec:
 
 # Dynamic Linear Economies
 
-This website presents a set of lectures on dynamic linear economies and tools needed for this this class of economic models.
+This website presents a set of lectures on dynamic linear economies and tools needed for this class of economic models.
 
 ```{tableofcontents}
 ```


### PR DESCRIPTION
This PR removes a typo in the `intro.md`.