### PR TITLE
Update Links to `myst` Format

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -88,6 +88,9 @@ sphinx:
       launch_buttons:
         colab_url                 : https://colab.research.google.com
     intersphinx_mapping:
+      pyprog:
+        - https://python-programming.quantecon.org/
+        - null
       intro: 
         - https://intro.quantecon.org/
         - null

--- a/lectures/lagrangian_lqdp.md
+++ b/lectures/lagrangian_lqdp.md
@@ -58,12 +58,12 @@ In focusing on eigenvalues and eigenvectors of this matrix, we capitalize on an 
 **invariant subspaces.** 
 
 These invariant subspace formulations of LQ dynamic programming problems provide a bridge between recursive
-(i.e., dynamic programming) formulations and classical formulations of linear control and linear filtering problems that make use of related matrix decompositions (see for example [this lecture](https://python-advanced.quantecon.org/lu_tricks.html) and [this lecture](https://python-advanced.quantecon.org/classical_filtering.html)).
+(i.e., dynamic programming) formulations and classical formulations of linear control and linear filtering problems that make use of related matrix decompositions (see for example {doc}`this lecture <tools:lu_tricks>` and {doc}`this lecture <tools:classical_filtering>`).
 
 While most of this lecture focuses on undiscounted problems, later sections describe handy ways of transforming discounted problems to undiscounted ones.
 
 The techniques in this lecture will prove useful when we study Stackelberg and Ramsey problem in
-[this lecture](https://python-advanced.quantecon.org/dyn_stack.html). 
+{doc}`this lecture <dps:dyn_stack>`. 
 
 
   
@@ -451,7 +451,7 @@ solves. See {cite}`Ljungqvist2012`,  ch 12.
 
 ## Application
 
-Here we demonstrate the computation with an example which is the deterministic version of an example borrowed from this [quantecon lecture](https://python.quantecon.org/lqcontrol.html).
+Here we demonstrate the computation with an example which is the deterministic version of an example borrowed from this {doc}`quantecon lecture <dle:lqcontrol>`.
 
 ```{code-cell} ipython3
 # Model parameters
@@ -826,7 +826,7 @@ which in the special case that $\beta = 1$ agrees with equation {eq}`lag-lqdp-eq
 
 +++
 
-By staring at system {eq}`eq663`, we can infer  identities that shed light on the structure of optimal linear regulator problems, some of which will be useful in [this lecture](https://python-advanced.quantecon.org/dyn_stack.html) when we apply and  extend the methods of this lecture to study Stackelberg and Ramsey problems.
+By staring at system {eq}`eq663`, we can infer  identities that shed light on the structure of optimal linear regulator problems, some of which will be useful in {doc}`this lecture <dps:dyn_stack>` when we apply and  extend the methods of this lecture to study Stackelberg and Ramsey problems.
 
 First, note that the first block of equation system {eq}`eq663` asserts that when  $\mu_{t+1} = P x_{t+1}$, then   
 

--- a/lectures/lqcontrol.md
+++ b/lectures/lqcontrol.md
@@ -51,7 +51,7 @@ These themes appear repeatedly below.
 Mathematically, LQ control problems are closely related to {doc}`the Kalman filter <kalman>`
 
 * Recursive formulations of linear-quadratic control problems and Kalman filtering problems both involve matrix **Riccati equations**.
-* Classical formulations of linear control and linear filtering problems make use of similar matrix decompositions (see for example [this lecture](https://python-advanced.quantecon.org/lu_tricks.html) and [this lecture](https://python-advanced.quantecon.org/classical_filtering.html)).
+* Classical formulations of linear control and linear filtering problems make use of similar matrix decompositions (see for example {doc}`this lecture <tools:lu_tricks>` and {doc}`this lecture <tools:classical_filtering>`).
 
 In reading what follows, it will be useful to have some familiarity with
 

--- a/lectures/perm_income_cons.md
+++ b/lectures/perm_income_cons.md
@@ -160,7 +160,7 @@ then the two models are mathematically equivalent.
 
 All characterizations of a $\{c_t, y_t, b_t\}$ in the LQ permanent income model automatically apply to a $\{T_t, G_t, B_t\}$ process in the Barro model of tax smoothing.
 
-See [consumption and tax smoothing models](https://python-advanced.quantecon.org/smoothing.html) for further exploitation of an isomorphism between consumption and tax smoothing models.
+See {doc}`consumption and tax smoothing models <dle:smoothing>` for further exploitation of an isomorphism between consumption and tax smoothing models.
 
 ### A Specification of the Nonfinancial Income Process
 

--- a/lectures/troubleshooting.md
+++ b/lectures/troubleshooting.md
@@ -33,7 +33,7 @@ The basic assumption of the lectures is that code in a lecture should execute wh
 1. it is executed in a Jupyter notebook and
 1. the notebook is running on a machine with the latest version of Anaconda Python.
 
-You have installed Anaconda, haven't you, following the instructions in [this lecture](https://python-programming.quantecon.org/getting_started.html)?
+You have installed Anaconda, haven't you, following the instructions in {doc}`this lecture <pyprog:getting_started>`?
 
 Assuming that you have, the most common source of problems for our readers is that their Anaconda distribution is not up to date.
 


### PR DESCRIPTION
This completes the first stage of https://github.com/QuantEcon/meta/issues/119